### PR TITLE
feat: support Paymaster calculateGasLimit false

### DIFF
--- a/src/sdk/clients/createSCSPaymasterClient.ts
+++ b/src/sdk/clients/createSCSPaymasterClient.ts
@@ -1,20 +1,29 @@
 import { http, type Address, type OneOf, type Transport } from "viem"
 import {
+  type GetPaymasterStubDataParameters,
+  type GetPaymasterStubDataReturnType,
   type PaymasterClient,
   type PaymasterClientConfig,
   type SmartAccount,
-  createPaymasterClient,
+  createPaymasterClient
 } from "viem/account-abstraction"
+import type { StartaleSmartAccountImplementation } from "../account"
+import type { AnyData } from "../modules/utils/Types"
 import {
   type TokenPaymasterActions,
   scsTokenPaymasterActions
 } from "./decorators/tokenPaymaster"
-import { getTokenPaymasterQuotes, type GetTokenPaymasterQuotesParameters } from "./decorators/tokenPaymaster/getTokenPaymasterQuotes"
-import { type StartaleSmartAccountImplementation } from "../account"
-import type { AnyData } from "../modules/utils/Types"
+import {
+  type GetTokenPaymasterQuotesParameters,
+  getTokenPaymasterQuotes
+} from "./decorators/tokenPaymaster/getTokenPaymasterQuotes"
 
 export type SCSPaymasterClient = Omit<PaymasterClient, "getPaymasterStubData"> &
-  TokenPaymasterActions
+  TokenPaymasterActions & {
+    getPaymasterStubData: (
+      parameters: GetPaymasterStubDataParameters
+    ) => Promise<GetPaymasterStubDataReturnType>
+  }
 
 /**
  * Configuration options for creating a SCS Paymaster Client.
@@ -125,29 +134,57 @@ export const createSCSPaymasterClient = (
           `https://paymaster.scs.startale.com/v1?apikey=${parameters.apiKey}`
         )
 
-  // Todo: Update default to https://dev.paymaster.scs.startale.com/v1?apikey=scsadmin-paymaster (or prod)
+  // The SCS paymaster server does not implement pm_getPaymasterStubData, so we strip viem's
+  // built-in getPaymasterStubData and provide a custom one that supports both modes:
+  //
+  // calculateGasLimits: true  — delegate to getPaymasterData directly; server computes gas and
+  //   returns all fields in one shot, so viem skips bundler estimation naturally.
+  //
+  // calculateGasLimits: false — two-phase flow:
+  //   1. Stub: call pm_getPaymasterData with calculateGasLimits:true (server accepts zero-gas
+  //      stubs under this mode), then return isFinal:false so viem proceeds to bundler estimation.
+  //   2. Final: viem calls pm_getPaymasterData with real gas values + calculateGasLimits:false.
+  const { getPaymasterStubData: _serverStub, ...baseClient } =
+    createPaymasterClient({
+      ...parameters,
+      transport: defaultedTransport
+    })
+      .extend((client: AnyData) => ({
+        getTokenPaymasterQuotes: async (
+          args: GetTokenPaymasterQuotesParameters
+        ) => {
+          const _args = args
+          // Review
+          if (args.userOp?.authorization) {
+            const authorization =
+              args.userOp.authorization ||
+              (await (
+                client.account as SmartAccount<StartaleSmartAccountImplementation>
+              )?.eip7702Authorization?.())
+            args.userOp.authorization = authorization
+          }
+          return await getTokenPaymasterQuotes(client, _args)
+        }
+      }))
+      .extend(scsTokenPaymasterActions())
 
-  // Remove getPaymasterStubData from the client.
-  const { getPaymasterStubData, ...paymasterClient } = createPaymasterClient({
-    ...parameters,
-    transport: defaultedTransport
-  })
-  .extend((client: AnyData) => ({
-    getTokenPaymasterQuotes: async (args: GetTokenPaymasterQuotesParameters) => {
-      let _args = args
-      // Review
-      if (args.userOp?.authorization) {
-        const authorization =
-          args.userOp.authorization ||
-          (await (
-            client.account as SmartAccount<StartaleSmartAccountImplementation>
-          )?.eip7702Authorization?.())
-        args.userOp.authorization = authorization
-      }
-      return await getTokenPaymasterQuotes(client, _args)
+  const getPaymasterStubData = async (
+    params: GetPaymasterStubDataParameters
+  ): Promise<GetPaymasterStubDataReturnType> => {
+    const context = params.context as SCSPaymasterContext | undefined
+    if (context?.calculateGasLimits === false) {
+      const stubData = await baseClient.getPaymasterData({
+        ...params,
+        context: { ...context, calculateGasLimits: true }
+      })
+      // paymasterPostOpGasLimit is always present when calculateGasLimits:true, cast is safe
+      return { ...stubData, isFinal: false } as GetPaymasterStubDataReturnType
     }
-  }))
-  .extend(scsTokenPaymasterActions())
+    // calculateGasLimits: true — single-phase, gas populated by paymaster
+    return baseClient.getPaymasterData(
+      params
+    ) as unknown as GetPaymasterStubDataReturnType
+  }
 
-  return paymasterClient
+  return { ...baseClient, getPaymasterStubData }
 }

--- a/src/sdk/core.test.ts
+++ b/src/sdk/core.test.ts
@@ -81,7 +81,7 @@ describe("core", async () => {
     const smartAccountBalance = await testClient.getBalance({
       address: startaleAccountAddress
     })
-    if (smartAccountBalance == 0n) {
+    if (smartAccountBalance === 0n) {
       const hash = await walletClient.sendTransaction({
         chain,
         account: eoaAccount,


### PR DESCRIPTION
## feat: Support `calculateGasLimits: false` in  `createSCSPaymasterClient`                                          
                                                                        
   
  ### Solution                                                          
                                                            
  Replace the "strip and discard" approach with a custom
  `getPaymasterStubData` that handles both modes:

  **`calculateGasLimits: true`** — delegates directly to                
  `getPaymasterData`. Paymaster computes and
  returns all gas fields in one shot; viem naturally skips bundler      
  estimation. Existing behaviour preserved.                 

  **`calculateGasLimits: false`** — two-phase flow:                     
  1. **Stub**: calls `pm_getPaymasterData` with `calculateGasLimits:
  true` temporarily (server accepts                                     
     zero-gas stubs under this mode). Returns `isFinal: false` so viem
  proceeds to bundler gas estimation                                    
     via `eth_estimateUserOperationGas`.
  2. **Final**: viem calls `pm_getPaymasterData` with real              
  bundler-estimated gas values and                                      
     `calculateGasLimits: false` for the actual sponsorship.
                                                                        
  ### Changes                                               

  - `src/sdk/clients/createSCSPaymasterClient.ts` — custom              
  `getPaymasterStubData`, updated
    `SCSPaymasterClient` type to include it                             
  - `src/sdk/core.test.ts` — fix pre-existing biome lint error (`==` →
  `===`)                                                                
   
  ### Verified on Soneium Mainnet (`calculateGasLimits: false`)         
                                                            
  | | |
  |---|---|
  | **UserOp Hash** |
  `0xc2468e8c0a1de81dc483582c3b37f5ee33724aaa1edc5e351853a3401739db9b` |
  | **Tx Hash** |
  `0xd828fee2d577b5b5fbd8ce291ae31cc70f02d047da7555772844e9ca007e733d` |
  | **Block** | `21862257` |                                
  | **Sender** | `0x5d824DDdBFa0E29d9c404AD928Fa4f9da0d73DE9` |         
  | **Paymaster** | `0x00000095901E8AB695Dc24FA52B0Cce15E9896Ad` |      
  | **Status** | `success` ✅ |                                         
  | **Gas Used** | `1,081,983` (estimated by bundler) |   