### PR TITLE
feat: support calculateGasLimits false as default two-phase paymaster flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@startale-scs/aa-sdk",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "author": "SCS",
   "repository": {
     "type": "git",

--- a/src/sdk/clients/createSCSPaymasterClient.test.ts
+++ b/src/sdk/clients/createSCSPaymasterClient.test.ts
@@ -2,15 +2,25 @@ import {
   http,
   type Address,
   type Chain,
+  type Hex,
   type PrivateKeyAccount,
   type PublicClient,
   type WalletClient,
   createPublicClient,
   createWalletClient,
+  custom,
   parseUnits,
   toHex
 } from "viem"
-import { afterAll, beforeAll, describe, expect, test } from "vitest"
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi
+} from "vitest"
 import { paymasterTruthy, toNetwork } from "../../test/testSetup"
 import {
   getBalance,
@@ -116,8 +126,9 @@ describe.skipIf(!paymasterTruthy())("scs.paymaster", async () => {
     expect(paymaster).toHaveProperty("getPaymasterData")
     expect(paymaster.getPaymasterData).toBeInstanceOf(Function)
 
-    // SCS Paymaster has no getPaymasterStubData method, to ensure latency is kept low.
-    expect(paymaster).not.toHaveProperty("getPaymasterStubData")
+    // SCS Paymaster exposes getPaymasterStubData to support the two-phase flow (calculateGasLimits: false)
+    expect(paymaster).toHaveProperty("getPaymasterStubData")
+    expect(paymaster.getPaymasterStubData).toBeInstanceOf(Function)
   })
 
   test.skip("should send a sponsored transaction", async () => {
@@ -375,5 +386,149 @@ describe.skipIf(!paymasterTruthy())("scs.paymaster", async () => {
       (token) => token.tokenAddress
     )
     expect(supportedTokenAddresses).toContain(soneiumMinatoASTRAddress)
+  })
+})
+
+// ─── Unit tests (no network required) ────────────────────────────────────────
+
+const MOCK_PAYMASTER_ADDRESS =
+  "0x0000007d3cd3002cb096568ba3cc1319c03f2a55" as Address
+const MOCK_STUB_RESPONSE = {
+  paymaster: MOCK_PAYMASTER_ADDRESS,
+  paymasterData: "0xdeadbeef" as Hex,
+  paymasterVerificationGasLimit: "0x30d40", // 200000
+  paymasterPostOpGasLimit: "0x186a0" // 100000
+}
+const MOCK_DATA_RESPONSE = {
+  paymaster: MOCK_PAYMASTER_ADDRESS,
+  paymasterData: "0xfinaldata" as Hex
+}
+const MINIMAL_STUB_PARAMS = {
+  chainId: 1946,
+  entryPointAddress: "0x0000000071727De22E5E9d8BAf0edAc6f37da032" as Address,
+  sender: "0x0000000000000000000000000000000000000001" as Address,
+  callData: "0x" as Hex,
+  nonce: 0n,
+  maxFeePerGas: 1n,
+  maxPriorityFeePerGas: 1n,
+  callGasLimit: 0n,
+  verificationGasLimit: 0n,
+  preVerificationGas: 0n
+}
+
+describe("toSCSSponsoredPaymasterContext", () => {
+  test("defaults calculateGasLimits to false", () => {
+    const ctx = toSCSSponsoredPaymasterContext()
+    expect(ctx.calculateGasLimits).toBe(false)
+  })
+
+  test("allows overriding calculateGasLimits to true", () => {
+    const ctx = toSCSSponsoredPaymasterContext({ calculateGasLimits: true })
+    expect(ctx.calculateGasLimits).toBe(true)
+  })
+
+  test("preserves paymasterId alongside default calculateGasLimits", () => {
+    const ctx = toSCSSponsoredPaymasterContext({ paymasterId: "pm_test" })
+    expect(ctx.calculateGasLimits).toBe(false)
+    expect(ctx.paymasterId).toBe("pm_test")
+  })
+})
+
+describe("toSCSTokenPaymasterContext", () => {
+  const tokenAddress = "0x26e6f7c7047252DdE3dcBF26AA492e6a264Db655" as Address
+
+  test("defaults calculateGasLimits to false", () => {
+    const ctx = toSCSTokenPaymasterContext({ token: tokenAddress })
+    expect(ctx.calculateGasLimits).toBe(false)
+  })
+
+  test("allows overriding calculateGasLimits to true", () => {
+    const ctx = toSCSTokenPaymasterContext({
+      token: tokenAddress,
+      calculateGasLimits: true
+    })
+    expect(ctx.calculateGasLimits).toBe(true)
+  })
+
+  test("sets token address", () => {
+    const ctx = toSCSTokenPaymasterContext({ token: tokenAddress })
+    expect(ctx.token).toBe(tokenAddress)
+  })
+})
+
+describe("createSCSPaymasterClient - getPaymasterStubData routing", () => {
+  let mockRequest: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockRequest = vi.fn(async ({ method }: { method: string }) => {
+      if (method === "pm_getPaymasterStubData") return MOCK_STUB_RESPONSE
+      if (method === "pm_getPaymasterData") return MOCK_DATA_RESPONSE
+      return null
+    })
+  })
+
+  test("calls pm_getPaymasterStubData when calculateGasLimits is false", async () => {
+    const client = createSCSPaymasterClient({
+      transport: custom({ request: mockRequest })
+    })
+
+    await client.getPaymasterStubData({
+      ...MINIMAL_STUB_PARAMS,
+      context: { calculateGasLimits: false, paymasterId: "pm_test" }
+    })
+
+    const methods = mockRequest.mock.calls.map(
+      (call: [{ method: string }]) => call[0].method
+    )
+    expect(methods).toContain("pm_getPaymasterStubData")
+    expect(methods).not.toContain("pm_getPaymasterData")
+  })
+
+  test("calls pm_getPaymasterData when calculateGasLimits is true (single-phase)", async () => {
+    const client = createSCSPaymasterClient({
+      transport: custom({ request: mockRequest })
+    })
+
+    await client.getPaymasterStubData({
+      ...MINIMAL_STUB_PARAMS,
+      context: { calculateGasLimits: true, paymasterId: "pm_test" }
+    })
+
+    const methods = mockRequest.mock.calls.map(
+      (call: [{ method: string }]) => call[0].method
+    )
+    expect(methods).toContain("pm_getPaymasterData")
+    expect(methods).not.toContain("pm_getPaymasterStubData")
+  })
+
+  test("calls pm_getPaymasterStubData when context is undefined (default is false)", async () => {
+    const client = createSCSPaymasterClient({
+      transport: custom({ request: mockRequest })
+    })
+
+    await client.getPaymasterStubData({
+      ...MINIMAL_STUB_PARAMS,
+      context: undefined
+    })
+
+    const methods = mockRequest.mock.calls.map(
+      (call: [{ method: string }]) => call[0].method
+    )
+    expect(methods).toContain("pm_getPaymasterStubData")
+    expect(methods).not.toContain("pm_getPaymasterData")
+  })
+
+  test("stub response includes paymasterVerificationGasLimit and paymasterPostOpGasLimit", async () => {
+    const client = createSCSPaymasterClient({
+      transport: custom({ request: mockRequest })
+    })
+
+    const result = await client.getPaymasterStubData({
+      ...MINIMAL_STUB_PARAMS,
+      context: { calculateGasLimits: false, paymasterId: "pm_test" }
+    })
+
+    expect(result.paymasterVerificationGasLimit).toBeDefined()
+    expect(result.paymasterPostOpGasLimit).toBeDefined()
   })
 })

--- a/src/sdk/clients/createSCSPaymasterClient.ts
+++ b/src/sdk/clients/createSCSPaymasterClient.ts
@@ -1,7 +1,5 @@
 import { http, type Address, type OneOf, type Transport } from "viem"
 import {
-  type GetPaymasterStubDataParameters,
-  type GetPaymasterStubDataReturnType,
   type PaymasterClient,
   type PaymasterClientConfig,
   type SmartAccount,
@@ -18,12 +16,7 @@ import {
   getTokenPaymasterQuotes
 } from "./decorators/tokenPaymaster/getTokenPaymasterQuotes"
 
-export type SCSPaymasterClient = Omit<PaymasterClient, "getPaymasterStubData"> &
-  TokenPaymasterActions & {
-    getPaymasterStubData: (
-      parameters: GetPaymasterStubDataParameters
-    ) => Promise<GetPaymasterStubDataReturnType>
-  }
+export type SCSPaymasterClient = PaymasterClient & TokenPaymasterActions
 
 /**
  * Configuration options for creating a SCS Paymaster Client.
@@ -75,7 +68,7 @@ export const toSCSSponsoredPaymasterContext = (
   params?: Partial<SCSPaymasterContext>
 ): SCSPaymasterContext => {
   return {
-    calculateGasLimits: true,
+    calculateGasLimits: false,
     ...params
   }
 }
@@ -86,7 +79,7 @@ export const toSCSTokenPaymasterContext = (
   const { calculateGasLimits } = params
   return {
     token: params.token,
-    calculateGasLimits: calculateGasLimits ?? true
+    calculateGasLimits: calculateGasLimits ?? false
   }
 }
 
@@ -134,17 +127,7 @@ export const createSCSPaymasterClient = (
           `https://paymaster.scs.startale.com/v1?apikey=${parameters.apiKey}`
         )
 
-  // The SCS paymaster server does not implement pm_getPaymasterStubData, so we strip viem's
-  // built-in getPaymasterStubData and provide a custom one that supports both modes:
-  //
-  // calculateGasLimits: true  — delegate to getPaymasterData directly; server computes gas and
-  //   returns all fields in one shot, so viem skips bundler estimation naturally.
-  //
-  // calculateGasLimits: false — two-phase flow:
-  //   1. Stub: call pm_getPaymasterData with calculateGasLimits:true (server accepts zero-gas
-  //      stubs under this mode), then return isFinal:false so viem proceeds to bundler estimation.
-  //   2. Final: viem calls pm_getPaymasterData with real gas values + calculateGasLimits:false.
-  const { getPaymasterStubData: _serverStub, ...baseClient } =
+  const { getPaymasterStubData: nativeGetPaymasterStubData, ...baseClient } =
     createPaymasterClient({
       ...parameters,
       transport: defaultedTransport
@@ -154,7 +137,6 @@ export const createSCSPaymasterClient = (
           args: GetTokenPaymasterQuotesParameters
         ) => {
           const _args = args
-          // Review
           if (args.userOp?.authorization) {
             const authorization =
               args.userOp.authorization ||
@@ -168,22 +150,19 @@ export const createSCSPaymasterClient = (
       }))
       .extend(scsTokenPaymasterActions())
 
-  const getPaymasterStubData = async (
-    params: GetPaymasterStubDataParameters
-  ): Promise<GetPaymasterStubDataReturnType> => {
+  const getPaymasterStubData: typeof nativeGetPaymasterStubData = async (
+    params
+  ) => {
     const context = params.context as SCSPaymasterContext | undefined
-    if (context?.calculateGasLimits === false) {
-      const stubData = await baseClient.getPaymasterData({
-        ...params,
-        context: { ...context, calculateGasLimits: true }
-      })
-      // paymasterPostOpGasLimit is always present when calculateGasLimits:true, cast is safe
-      return { ...stubData, isFinal: false } as GetPaymasterStubDataReturnType
+    if (context?.calculateGasLimits === true) {
+      // Single-phase: paymaster estimates gas internally, bundler estimation skipped
+      return baseClient.getPaymasterData(params) as ReturnType<
+        typeof nativeGetPaymasterStubData
+      >
     }
-    // calculateGasLimits: true — single-phase, gas populated by paymaster
-    return baseClient.getPaymasterData(
-      params
-    ) as unknown as GetPaymasterStubDataReturnType
+    // Two-phase (default): pm_getPaymasterStubData returns stub + gas limits,
+    // bundler estimates gas, pm_getPaymasterData signs only
+    return nativeGetPaymasterStubData(params)
   }
 
   return { ...baseClient, getPaymasterStubData }

--- a/src/sdk/clients/createSCSPaymasterClient.ts
+++ b/src/sdk/clients/createSCSPaymasterClient.ts
@@ -1,20 +1,29 @@
 import { http, type Address, type OneOf, type Transport } from "viem"
 import {
+  type GetPaymasterStubDataParameters,
+  type GetPaymasterStubDataReturnType,
   type PaymasterClient,
   type PaymasterClientConfig,
   type SmartAccount,
-  createPaymasterClient,
+  createPaymasterClient
 } from "viem/account-abstraction"
+import type { StartaleSmartAccountImplementation } from "../account"
+import type { AnyData } from "../modules/utils/Types"
 import {
   type TokenPaymasterActions,
   scsTokenPaymasterActions
 } from "./decorators/tokenPaymaster"
-import { getTokenPaymasterQuotes, type GetTokenPaymasterQuotesParameters } from "./decorators/tokenPaymaster/getTokenPaymasterQuotes"
-import { type StartaleSmartAccountImplementation } from "../account"
-import type { AnyData } from "../modules/utils/Types"
+import {
+  type GetTokenPaymasterQuotesParameters,
+  getTokenPaymasterQuotes
+} from "./decorators/tokenPaymaster/getTokenPaymasterQuotes"
 
 export type SCSPaymasterClient = Omit<PaymasterClient, "getPaymasterStubData"> &
-  TokenPaymasterActions
+  TokenPaymasterActions & {
+    getPaymasterStubData: (
+      parameters: GetPaymasterStubDataParameters
+    ) => Promise<GetPaymasterStubDataReturnType>
+  }
 
 /**
  * Configuration options for creating a SCS Paymaster Client.
@@ -125,29 +134,57 @@ export const createSCSPaymasterClient = (
           `https://paymaster.scs.startale.com/v1?apikey=${parameters.apiKey}`
         )
 
-  // Todo: Update default to https://dev.paymaster.scs.startale.com/v1?apikey=scsadmin-paymaster (or prod)
+  // The SCS paymaster server does not implement pm_getPaymasterStubData, so we strip viem's
+  // built-in getPaymasterStubData and provide a custom one that supports both modes:
+  //
+  // calculateGasLimits: true  — delegate to getPaymasterData directly; server computes gas and
+  //   returns all fields in one shot, so viem skips bundler estimation naturally.
+  //
+  // calculateGasLimits: false — two-phase flow:
+  //   1. Stub: call pm_getPaymasterData with calculateGasLimits:true (server accepts zero-gas
+  //      stubs under this mode), then return isFinal:false so viem proceeds to bundler estimation.
+  //   2. Final: viem calls pm_getPaymasterData with real gas values + calculateGasLimits:false.
+  const { getPaymasterStubData: _serverStub, ...baseClient } =
+    createPaymasterClient({
+      ...parameters,
+      transport: defaultedTransport
+    })
+      .extend((client: AnyData) => ({
+        getTokenPaymasterQuotes: async (
+          args: GetTokenPaymasterQuotesParameters
+        ) => {
+          const _args = args
+          // Review
+          if (args.userOp?.authorization) {
+            const authorization =
+              args.userOp.authorization ||
+              (await (
+                client.account as SmartAccount<StartaleSmartAccountImplementation>
+              )?.eip7702Authorization?.())
+            args.userOp.authorization = authorization
+          }
+          return await getTokenPaymasterQuotes(client, _args)
+        }
+      }))
+      .extend(scsTokenPaymasterActions())
 
-  // Remove getPaymasterStubData from the client.
-  const { getPaymasterStubData, ...paymasterClient } = createPaymasterClient({
-    ...parameters,
-    transport: defaultedTransport
-  })
-  .extend((client: AnyData) => ({
-    getTokenPaymasterQuotes: async (args: GetTokenPaymasterQuotesParameters) => {
-      let _args = args
-      // Review
-      if (args.userOp?.authorization) {
-        const authorization =
-          args.userOp.authorization ||
-          (await (
-            client.account as SmartAccount<StartaleSmartAccountImplementation>
-          )?.eip7702Authorization?.())
-        args.userOp.authorization = authorization
-      }
-      return await getTokenPaymasterQuotes(client, _args)
+  const getPaymasterStubData = async (
+    params: GetPaymasterStubDataParameters
+  ): Promise<GetPaymasterStubDataReturnType> => {
+    const context = params.context as SCSPaymasterContext | undefined
+    if (context?.calculateGasLimits === false) {
+      const stubData = await baseClient.getPaymasterData({
+        ...params,
+        context: { ...context, calculateGasLimits: true }
+      })
+      // paymasterPostOpGasLimit is always present when calculateGasLimits:true, cast is safe
+      return { ...stubData, isFinal: false } as GetPaymasterStubDataReturnType
     }
-  }))
-  .extend(scsTokenPaymasterActions())
+    // calculateGasLimits: true — single-phase, gas populated by paymaster
+    return baseClient.getPaymasterData(
+      params
+    ) as unknown as GetPaymasterStubDataReturnType
+  }
 
-  return paymasterClient
+  return { ...baseClient, getPaymasterStubData }
 }

--- a/src/sdk/core.test.ts
+++ b/src/sdk/core.test.ts
@@ -81,7 +81,7 @@ describe("core", async () => {
     const smartAccountBalance = await testClient.getBalance({
       address: startaleAccountAddress
     })
-    if (smartAccountBalance == 0n) {
+    if (smartAccountBalance === 0n) {
       const hash = await walletClient.sendTransaction({
         chain,
         account: eoaAccount,


### PR DESCRIPTION
## Summary

- **Default flow changed to `calculateGasLimits: false`** (two-phase): SDK calls `pm_getPaymasterStubData` natively, bundler estimates gas, paymaster signs only in `pm_getPaymasterData`
- **`calculateGasLimits: true` still supported** (single-phase): paymaster estimates gas internally, bundler estimation skipped
- `toSCSSponsoredPaymasterContext` and `toSCSTokenPaymasterContext` now default to `calculateGasLimits: false`
- `SCSPaymasterClient` type now exposes `getPaymasterStubData` (previously omitted)

## Why

`calculateGasLimits: false` is the better default:
- Steps after user hits Submit: sign only → submit → inclusion (gas estimation can be pre-fetched before Submit)
- `calculateGasLimits: true` requires paymaster to call bundler internally — slower, no pre-fetch possible, FE loses gas price control

Prerequisite: paymaster service PR that makes `pm_getPaymasterStubData` return `paymasterPostOpGasLimit` and `paymasterVerificationGasLimit` from config, so the bundler can estimate gas correctly.

## Test plan

- [x] `calculateGasLimits: false` — tx `0xccd169aafc9942111ed95513036d0bcf108e718d8e25b113efc6af5d5b876779` (Soneium mainnet)
- [x] `calculateGasLimits: true` — tx `0x355f5bf606f2a4e0827419f1370b302b1765ae0d33de8aaf2dc7a3175e9e725d` (Soneium mainnet)

